### PR TITLE
Improves mobile responsive resizing for fonts/buttons/logo, and reduces header size

### DIFF
--- a/components/Button.module.css
+++ b/components/Button.module.css
@@ -1,5 +1,6 @@
 .button {
     width: 100px;
+    max-width: 95%;
     padding: 8px;
 
     text-align: center;

--- a/components/Home.module.css
+++ b/components/Home.module.css
@@ -50,7 +50,6 @@
     .body {
         width: 70%;
         min-width: 360px;
-        max-width: 1000px;
     }
 }
 

--- a/components/Home.module.css
+++ b/components/Home.module.css
@@ -4,9 +4,7 @@
 
 .content {
     margin: auto;
-    width: 70%;
-    min-width: 360px;
-    max-width: 1000px;
+    width: 95%;
 }
 
 .nextContainer {
@@ -46,6 +44,14 @@
     margin-left: auto;
     margin-right: auto;
     display: block;
+}
+
+@media screen and (min-width: 480px) {
+    .body {
+        width: 70%;
+        min-width: 360px;
+        max-width: 1000px;
+    }
 }
 
 @media screen and (min-width: 768px) {

--- a/components/Logo.js
+++ b/components/Logo.js
@@ -1,19 +1,10 @@
 import Link from "next/link";
+import Styles from "./Logo.module.css"
 
 const Logo = (props) => {
-    let divStyle = {
-        display: 'flex',
-        justifyContent: 'center',
-        width: '100%',
-        marginBottom: '20px',
-    }
-    let imgStyle = {
-        margin: 'auto',
-        width: '240px',
-    }
     return (
-        <div style={divStyle}>
-            <img style={imgStyle} src='./QAFLogoOrangePuffy.png'></img>
+        <div className={Styles.container}>
+            <img className={Styles.logoImg} src='./QAFLogoOrangePuffy.png'></img>
         </div>
     )
 }

--- a/components/Logo.module.css
+++ b/components/Logo.module.css
@@ -1,0 +1,16 @@
+.container {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-bottom: 20px;
+}
+.logoImg {
+    margin: auto;
+    width: 100px;
+}
+
+@media screen and (min-width: 480px) {
+    .logoImg {
+        width: 180px;
+    }
+}

--- a/components/styles.css
+++ b/components/styles.css
@@ -155,15 +155,15 @@ p {
 
 @media screen and (min-width: 480px) {
     h1 {
-        font-size: 90pt;
+        font-size: 90px;
     }
     h2 {
-        font-size: 80pt;
+        font-size: 80px;
     }
     h3 {
-        font-size: 20pt;
+        font-size: 27px;
     }
     p {
-        font-size: 16pt;
+        font-size: 21px;
     }
 }


### PR DESCRIPTION
This pull request
* puts all global font sizes in px instead of pt
* reduces global h1/h2 font sizes on both desktop and mobile
* ensures that buttons with custom sizes don't exceed screen width, even for small mobile screens (less than 300px)
* ensures that all home page content doesn't exceed screen width, even for small mobile screens