### PR TITLE
Adds instagram link to instagram button

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -57,6 +57,7 @@ const Footer = (props) => {
                         hoverBackgroundColor="#002809"
                         hoverTextColor="white"
                         width='300px'
+                        url='https://www.instagram.com/queerartfairsf/'
                         />
 
                 </div>


### PR DESCRIPTION
The instagram button in the footer now links to the queer art fair Instagram account.