### PR TITLE
Adds item image urls to item upon creation, creates item pages, and displays item images on given page

### DIFF
--- a/app/items/[id]/page.js
+++ b/app/items/[id]/page.js
@@ -1,12 +1,13 @@
 'use client'
 import { useState, useEffect } from "react"
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { redirect } from "next/navigation";
 
 export default function Page({params}) {
     const [item, setItem] = useState();
     const supabase = createClientComponentClient()
 
-    // function to find the shop id and make sure the shop exists
+    // function to find the item id and make sure the item exists
     async function getItem() {
         let { data, error } = await supabase
             .from('items')
@@ -15,7 +16,8 @@ export default function Page({params}) {
             .single()
         if (error) {
             console.warn(error)
-            setItems(null) // assuming the shop doesn't exist
+            setItem(null) // assuming the item doesn't exist
+            redirect('/') // redirect to home if the item doesn't exist
         } else if (data) {
             setItem(data)
         }

--- a/app/items/[id]/page.js
+++ b/app/items/[id]/page.js
@@ -35,7 +35,7 @@ export default function Page({params}) {
 
             {item.image_urls.map(url => {
                 return (
-                    <img src={url} width='200px'></img>
+                    <img key={url} src={url} width='200px'></img>
                 )
             })}
         </> }

--- a/app/items/[id]/page.js
+++ b/app/items/[id]/page.js
@@ -2,35 +2,60 @@
 import { useState, useEffect } from "react"
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 
 export default function Page({params}) {
     const [item, setItem] = useState();
+    const [shopUrl, setShopUrl] = useState();
+    const [shopName, setShopName] = useState();
     const supabase = createClientComponentClient()
 
-    // function to find the item id and make sure the item exists
-    async function getItem() {
-        let { data, error } = await supabase
-            .from('items')
-            .select()
-            .eq('id', params.id)
-            .single()
-        if (error) {
-            console.warn(error)
-            setItem(null) // assuming the item doesn't exist
-            redirect('/') // redirect to home if the item doesn't exist
-        } else if (data) {
-            setItem(data)
-        }
-    }
-
+    // finds the item id and make sure the item exists
     useEffect(() => {
+        async function getItem() {
+            let { data, error } = await supabase
+                .from('items')
+                .select()
+                .eq('id', params.id)
+                .single()
+            if (error) {
+                console.warn(error)
+                setItem(null) // assuming the item doesn't exist
+                redirect('/') // redirect to home if the item doesn't exist
+            } else if (data) {
+                setItem(data)
+            }
+        }
+
         getItem();
     }, [params.id])
+
+    // once we know the item exists, find the shop information
+    useEffect(() => {
+        async function getShopInfo() {
+            let { data, error } = await supabase
+                .from('shops')
+                .select()
+                .eq('id', item.shop_id)
+                .single()
+            
+            if (error) {
+                console.warn(error)
+            } else if (data) {
+                setShopName(data.name)
+                setShopUrl('/shops/'+data.name.split(' ').join('_'))
+            }
+        }
+
+        if (!item) return;
+        getShopInfo();
+    }, [item])
 
     return(
         <>
         { item && <>
             <h3>{item.name} - ${item.price}</h3>
+            {shopName && <p>Sold by <Link href={shopUrl}>{shopName}</Link></p>}
             <p>{item.description}</p>
 
             {item.image_urls.map(url => {

--- a/app/items/[id]/page.js
+++ b/app/items/[id]/page.js
@@ -1,0 +1,43 @@
+'use client'
+import { useState, useEffect } from "react"
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
+export default function Page({params}) {
+    const [item, setItem] = useState();
+    const supabase = createClientComponentClient()
+
+    // function to find the shop id and make sure the shop exists
+    async function getItem() {
+        let { data, error } = await supabase
+            .from('items')
+            .select()
+            .eq('id', params.id)
+            .single()
+        if (error) {
+            console.warn(error)
+            setItems(null) // assuming the shop doesn't exist
+        } else if (data) {
+            setItem(data)
+        }
+    }
+
+    useEffect(() => {
+        getItem();
+    }, [params.id])
+
+    return(
+        <>
+        { item && <>
+            <h3>{item.name} - ${item.price}</h3>
+            <p>{item.description}</p>
+
+            {item.image_urls.map(url => {
+                return (
+                    <img src={url} width='200px'></img>
+                )
+            })}
+        </> }
+        
+        </>
+    )
+}

--- a/app/new-item/item-form.jsx
+++ b/app/new-item/item-form.jsx
@@ -6,6 +6,7 @@
 // TODO: limit number of images added, functionality to delete images
 
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { redirect } from "next/navigation";
 import { useState, useEffect } from "react";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -17,6 +18,7 @@ export default function ItemForm({ session }) {
     const [loading, setLoading] = useState(true);
     const [shops, setShops] = useState([]);
     const [shopId, setShopId] = useState();
+    const [itemId, setId] = useState();
     const [itemName, setName] = useState();
     const [itemDescription, setDescription] = useState();
     const [itemPrice, setPrice] = useState();
@@ -24,59 +26,52 @@ export default function ItemForm({ session }) {
 
     const [images, setImages] = useState([]);
 
+    const [imageUrls, setImageUrls] = useState([]);
+
     const [formError, setFormError] = useState(null);
 
-    // get all of the seller's shops
-    async function getShops() {
-        setLoading(true);
-        let { data, error } = await supabase
-            .from('shops')
-            .select('id, name')
-            .eq('owner_id', user?.id)
-        if (error) {
-            console.warn(error);
-        } else if (data) {
-            setShops(data);
-        }
-        setLoading(false);
-    }
 
+    // get all of the seller's shops
     useEffect(() => {
+        async function getShops() {
+            setLoading(true);
+            let { data, error } = await supabase
+                .from('shops')
+                .select('id, name')
+                .eq('owner_id', user?.id)
+            if (error) {
+                console.warn(error);
+            } else if (data) {
+                setShops(data);
+            }
+            setLoading(false);
+        }
+
         getShops();
     }, [])
 
     async function getImage(e) {
         let file = e.target.files[0];
         if (file) {
-            setImages([ ...images, file]);
+            setImages(arr => [ ...arr, file]);
         }
     }
 
-    async function uploadImage(image, itemId) {
-        const { data, error } = await supabase
-                .storage
-                .from('item-photos')
-                .upload(itemId + '/' + uuidv4(), image)
-        if (error) {
-            setFormError(error.message)
-        }
-    }
-
-    async function uploadImages(itemId) {
-        await images.forEach(image => {
-            uploadImage(image, itemId)
-        })
-    }
-    // how the item is created and saved to the database
+    // adds a new row to the "items" table with the new item info (except the image urls)
     const createItem = async (e) => {
         e.preventDefault();
-        if (shops.length == 0) { setFormError("You must create a shop before adding an item."); return; }
-        if (!shopId)           { setFormError('You must select a shop or create a new one.');   return; }
-        if (!itemName)         { setFormError('You must add a name for your item.');            return; }
-        if (!itemDescription)  { setFormError('You must give a description of your item.');     return; }
-        if (!itemPrice)        { setFormError('Your item must have a price.');                  return; }
-        if (!itemQuantity)     { setFormError('You must provide a quantity for your item.');    return; }
+        if (shops.length == 0)  { setFormError("You must create a shop before adding an item.");  return; }
+        if (!shopId)            { setFormError('You must select a shop or create a new one.');    return; }
+        if (!itemName)          { setFormError('You must add a name for your item.');             return; }
+        if (!itemDescription)   { setFormError('You must give a description of your item.');      return; }
+        if (!itemPrice)         { setFormError('Your item must have a price.');                   return; }
+        if (!itemQuantity)      { setFormError('You must provide a quantity for your item.');     return; }
+        if (images.length == 0) { setFormError('You must add at least one image of your item. '); return; }
         
+        // reset imageUrls
+        setImageUrls([]);
+
+        // put the item in the database
         const { data, error } = await supabase
             .from('items')
             .insert([{
@@ -92,23 +87,92 @@ export default function ItemForm({ session }) {
             return;
         }
         if (data) {
-            setFormError(null);
-            uploadImages(data[0].id)
+            setId(data[0].id)
         }
     }
+    // itemId is set after the item has been added to the database via createItem.
+    useEffect (() => {
+
+        // uploads the image to supabase storage and adds the image's public url to imageUrls[]
+        async function uploadImage(image, itemId) {
+            const imageId = uuidv4();
+
+            const { data, error } = await supabase
+                    .storage
+                    .from('item-photos')
+                    .upload(itemId + '/' + imageId, image)
+            if (error) {
+                setFormError(error.message)
+                return
+            }
+            if (data) {
+                addImageUrl(data.path);
+            }
+        }
+
+        async function addImageUrl(path) {
+            // Add the image url to the item
+            const { data } = supabase
+                .storage
+                .from('item-photos')
+                .getPublicUrl(path)
+            if (data) {
+                setImageUrls( arr => [ ...arr, data.publicUrl])
+            }
+        }
+
+        async function uploadImages() {
+            // upload the images to supabase storage
+            await images.forEach(async image => {
+                await uploadImage(image, itemId)
+            })
+
+        }
+        
+        if (!itemId || imageUrls.length > 0) return;
+        // upload the images to item-photos bucket under folder [itemId]
+        uploadImages();
+        
+    }, [itemId])
+
+    // when all the image urls have been created (as uploadImages runs), add them to the items table
+    useEffect(() => {
+
+        async function updateItemImageUrls() {
+            // set the imageUrls
+            const { data, error } = await supabase
+                .from('items')
+                .update({ image_urls: imageUrls })
+                .eq('id', itemId)
+                .select()
+            
+
+            if(error) {
+                console.warn(error)
+            }
+            if (data) {
+            }
+        }
+
+        if (imageUrls.length !== images.length) return;
+        if (imageUrls.length == 0) return;
+        updateItemImageUrls();
+
+        // redirect to the new item
+        redirect('items/' + itemId.toString(), 'push');
+    }, [imageUrls])
 
     return (
-        <>
         <form onSubmit={createItem}>
             <select 
                 name='shops' 
-                onChange={(e)=> { setShopId(e.target.value) }}
+                onChange={(e)=> { setShopId(e.target.value)}}
             >
                 <option value={''}>--Select--</option>
                 {
                     shops.map(shop => {
                         return(
-                            <option value={shop.id}>{shop.name}</option>
+                            <option key={shop.id} value={shop.id}>{shop.name}</option>
                         )   
                     })
                 }
@@ -138,13 +202,14 @@ export default function ItemForm({ session }) {
             />
             <input
                 type='number'
+                min='1'
                 placeholder='Item Quantity'
                 onChange={(e) => {
                     setQuantity(e.target.value);
                 }}
             />
 
-            <input type="file" onChange={(e) => getImage(e)} />
+            <input type="file" accept="image/png, image/jpeg, image/jpg" onChange={(e) => getImage(e)} />
             {
                 images.map(image => {
                     return(
@@ -156,9 +221,7 @@ export default function ItemForm({ session }) {
             }
 
             <button disabled={loading}>Add</button>
-
             {formError && <p>{formError}</p>}
         </form>
-        </>
     )
 }   

--- a/app/shops/[shop]/page.jsx
+++ b/app/shops/[shop]/page.jsx
@@ -1,6 +1,7 @@
 'use client'
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 import Navigation from "../../../components/Navigation";
 import Strawberry from "../../../components/Strawberry";
@@ -32,9 +33,7 @@ export default function Page({params}) {
     async function getItems() {
         await getShopId()
 
-        if (!shopId) {
-            return
-        }
+        if (!shopId) return;
 
         let { data, error } = await supabase
             .from('items')
@@ -59,7 +58,7 @@ export default function Page({params}) {
         <Strawberry heading={shopName.toUpperCase()} showLargeStrawberry='none' />
         {items ? items.map((item) => (
             <div key={item.id}>
-                <h3>{item.name} - ${item.price}</h3>
+                <h3><Link href={'/items/'+item.id}>{item.name}</Link> - ${item.price}</h3>
                 <p>{item.description}</p>
             </div>
         )) : 


### PR DESCRIPTION
This pull request does the following:

- When an item is added to the database, the public URLs for its associated images are added to the item database entry. (The following column is filled out.)
<img width="255" alt="Screenshot 2023-07-11 at 4 36 24 PM" src="https://github.com/michellewong793/queer-art-fair-v2/assets/52363369/6b6eae40-e5ea-4098-b85b-dd1662a09a01">

- Each item can be viewed on a separate page (.../items/[item id]), with its associated images:
<img width="500" alt="Screenshot 2023-07-11 at 4 37 45 PM" src="https://github.com/michellewong793/queer-art-fair-v2/assets/52363369/92c6c7a2-49fe-4362-a7bd-e47cba545c8b">

- When a shop is displayed, each item preview contains a link to that item's page: 
<img width="400" alt="Screenshot 2023-07-11 at 4 39 55 PM" src="https://github.com/michellewong793/queer-art-fair-v2/assets/52363369/550b737a-862a-465b-af8b-86b17041c88a">