### PR TITLE
Requires password to continue to login page

### DIFF
--- a/app/components/forms/input.module.css
+++ b/app/components/forms/input.module.css
@@ -5,17 +5,24 @@
     display: inline-block;
 }
 
-.border {
-    width: 100%;
+.border, .checkboxBorder {
     border-bottom: 3px solid #B0B0B0;
     border-radius: 4px;
+}
+
+.border {
+    width: 100%;
+}
+
+.checkboxBorder {
+    width: fit-content;
 }
 
 .inputError .border {
     border-bottom: 3px solid #FF4D4D;
 }
 
-.input {
+.input, .checkbox {
     box-sizing: border-box;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -37,14 +44,21 @@
     overflow: visible;
 }
 
-.input:focus {
+.checkbox {
+    width: 30px;
+    height: 30px;
+    margin: 0;
+    cursor: pointer;
+}
+
+.input:focus, .checkbox:focus {
     outline: #FE88CC 2px solid;
     outline-offset: -3px;
 
     transform: translate(0px, 2px);
 }
 
-.input:disabled {
+.input:disabled, .checkbox:disabled {
     transform: translate(0px, 2px);
     cursor: not-allowed;
 }

--- a/app/components/forms/input.tsx
+++ b/app/components/forms/input.tsx
@@ -21,6 +21,7 @@ type InputProps = {
     error?: string,
     disabled?,
     onChange?,
+    onClick?,
 }
 
 const Input: React.FC<InputProps> = ({
@@ -37,6 +38,7 @@ const Input: React.FC<InputProps> = ({
     error,
     disabled,
     onChange,
+    onClick,
 }) => {
     
 
@@ -49,11 +51,20 @@ const Input: React.FC<InputProps> = ({
         }
     }
 
+    const handleClick = (event) => {
+        if (typeof onClick === "function") {
+            onClick({
+                value: event.target.value
+            })
+        }
+    }
+
     const fieldProps = {
         placeholder,
         value,
         disabled,
-        onChange: handleChange
+        onChange: handleChange,
+        onClick: handleClick
     }
     
     function inputSwitch() {
@@ -98,10 +109,25 @@ const Input: React.FC<InputProps> = ({
                         text={value}
                     />
                 )
+
+            case 'checkbox':
+                return (
+                    <div className={styles.checkboxBorder}>
+                        <input 
+                            className={styles.checkbox}
+                            type='checkbox'
+                            {...fieldProps}
+                        />
+                    </div>
+                )
             default:
                 return (
                     <div className={styles.border}>
-                    <input className={styles.input} {...fieldProps} />
+                    <input 
+                        className={styles.input} 
+                        type={type}
+                        {...fieldProps} 
+                    />
                     </div>
                 )
         }

--- a/app/login/PasswordProtection.js
+++ b/app/login/PasswordProtection.js
@@ -1,0 +1,50 @@
+'use client'
+import Label from '../components/forms/label'
+import Input from '../components/forms/input'
+import styles from './PasswordProtection.module.css'
+import { useState, useId } from 'react';
+
+// props = password, unlockWithPassword
+export default function PasswordProtection(props) {
+    const [enteredPassword, setEnteredPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false)
+    const [error, setError] = useState(null)
+    const passwordId = useId()
+    const checkId = useId()
+
+    async function checkPassword(e) {
+        e.preventDefault()
+        if (enteredPassword === props?.password) {
+            props?.unlockWithPassword()
+        } else {
+            setError('*Invalid password')
+        }
+    }
+
+    return (
+        <form onSubmit={(e) => checkPassword(e)}>
+            <Label htmlFor={passwordId}>Enter the Queer Art Faire password to continue to login.</Label>
+            <Input 
+                id={passwordId}
+                className={styles.input}
+                type={showPassword ? 'text' : 'password'}
+                placeholder={'Password'}
+                value={enteredPassword || ''}
+                error={error}
+                onChange={(data) => setEnteredPassword(data.value)}
+            />
+
+            <div className={styles.showPasswordContainer}>
+                <Input 
+                    id={checkId} 
+                    type="checkbox" 
+                    className={styles.input}
+                    onClick={() => setShowPassword(!showPassword)} 
+                />
+                <Label htmlFor={checkId}>Show password</Label>
+            </div>
+
+            <Input type='submit' value='Submit'/>
+        </form>
+    )
+}

--- a/app/login/PasswordProtection.module.css
+++ b/app/login/PasswordProtection.module.css
@@ -1,0 +1,9 @@
+.input {
+    margin-bottom: 20px;
+}
+
+.showPasswordContainer {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 32px;
+}

--- a/app/login/login.module.css
+++ b/app/login/login.module.css
@@ -43,6 +43,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 0 16px;
 }
 
 .enterEmail {

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -12,42 +12,65 @@ import Subheader from "../../components/Subheader";
 import Footer from "../../components/Footer";
 import style from './login.module.css';
 import Styles from "../../components/Theme";
+import PasswordProtection from './PasswordProtection'
 
 export default function Login() {
     const [email, setEmail] = useState();
-    return(
+    const [verifiedPassword, setVerifiedPassword] = useState(false)
+    const password = 'QueerArtFaire'
+
+    function loginForm() {
+
+        return (
+            <>
+                <div className = {style.heading}>
+                    Login
+                </div>
+                <Spacer height = {3}/>
+                <button className = {style.signInGoogle} onClick={() => signInWithGoogle()}>
+                    <img className = {style.googleLogo} src = {"../../googleLogo.svg"}/>
+                    <Spacer width = {1}/>
+                    <div className = {style.signInText}>
+                        Sign in with Google
+                    </div>
+                </button>
+                <Spacer height = {2} />
+                <div className = {style.bold}>OR</div>
+                <Spacer height = {2}/>
+                <input placeholder='Enter your email...' className = {style.enterEmail} onChange={(e) => setEmail(e.target.value)}></input>
+                <Spacer height = {1}/>
+                <button className = {style.emailSignIn} onClick={() => signInWithMagicLink({email: email})}>
+                    <div className = {style.signInText}>
+                        Sign in with magic link
+                    </div>
+                </button>
+            </>
+        )
+    }
+    
+    function passwordProtect () {
+        return (
+            <PasswordProtection 
+                password={password} 
+                unlockWithPassword={() => setVerifiedPassword(true)} 
+            />
+        )
+    }
+    
+    return (
         <div style = {Styles.body} className = {style.bodyBackground}>
-        <HeaderDecoration />
-        <Logo />
-        <Subheader />
-        <Navigation />
-        <Spacer height = {3}/>
-        <div className = {style.columnContainer}>
-            <div className = {style.heading}>
-                Login
-            </div>
+            <HeaderDecoration />
+            <Logo />
+            <Subheader />
+            <Navigation />
             <Spacer height = {3}/>
-            <button className = {style.signInGoogle} onClick={() => signInWithGoogle()}>
-                <img className = {style.googleLogo} src = {"../../googleLogo.svg"}/>
-                <Spacer width = {1}/>
-                <div className = {style.signInText}>
-                    Sign in with Google
-                </div>
-            </button>
-            <Spacer height = {2} />
-            <div className = {style.bold}>OR</div>
-            <Spacer height = {2}/>
-            <input placeholder='Enter your email...' className = {style.enterEmail} onChange={(e) => setEmail(e.target.value)}></input>
-            <Spacer height = {1}/>
-            <button className = {style.emailSignIn} onClick={() => signInWithMagicLink({email: email})}>
-                <div className = {style.signInText}>
-                    Sign in with magic link
-                </div>
-            </button>
+            <div className = {style.columnContainer}>
+                { verifiedPassword && loginForm() }
+                { !verifiedPassword && passwordProtect() }
+            </div>
+            <Footer />
         </div>
-        
-        <Footer />
-        </div>
-        
     )
+    
+    
 }


### PR DESCRIPTION
This prevents users from using the login/sign up page until they enter a password. The password is specified in app/login/page.js -- to change it, change the string in the password variable (I set it to "QueerArtFaire" as an initial password).

(Note that this will also prevent users that already have accounts from logging in until they enter the password, since the login page for returning users is the same as the sign up page for new users. This may be something we want to address.)

<img width="750" alt="Screenshot 2023-08-16 at 1 07 11 AM" src="https://github.com/michellewong793/queer-art-fair-v2/assets/52363369/3d7acdbd-ca6a-4ae6-a4a3-8df8340cef84">
